### PR TITLE
Fix scaling of FreezeShot

### DIFF
--- a/Shaders/FreezeShot.fx
+++ b/Shaders/FreezeShot.fx
@@ -351,15 +351,14 @@ uniform bool SCREENSHOT < source = "screenshot"; >;
 //float3 Freezef(float4 position : SV_Position, float2 texcoord : TexCoord, out float4 color : SV_Target)
 void Freezef(in float4 position : SV_Position, in float2 texcoord : TEXCOORD0, out float3 color : SV_Target)
 {
-    float2 Layer_Scalereal= float2 (Layer_Scale.x-0.44,(Layer_Scale.y-0.44)*BUFFER_WIDTH/BUFFER_HEIGHT);
-    float2 Layer_Posreal= float2((FlipH) ? -Layer_Pos.x : Layer_Pos.x, (FlipV) ? Layer_Pos.y:-Layer_Pos.y);
+    float2 Layer_Posreal = float2((FlipH) ? -Layer_Pos.x : Layer_Pos.x, (FlipV) ? Layer_Pos.y:-Layer_Pos.y);
 	float4 backbuffer = tex2D(ReShade::BackBuffer, texcoord).rgba;
 	float depth = 1 - ReShade::GetLinearizedDepth(texcoord).r;
-    float2 uvtemp= texcoord;
+    float2 uvtemp = texcoord;
     if (FlipH) {uvtemp.x = 1-uvtemp.x;}//horizontal flip
     if (FlipV) {uvtemp.y = 1-uvtemp.y;} //vertical flip
-	uvtemp=float2(((uvtemp.x*BUFFER_WIDTH-(BUFFER_WIDTH-BUFFER_HEIGHT)/2)/BUFFER_HEIGHT),uvtemp.y);
-    uvtemp=(rotate(uvtemp,Layer_Posreal+0.5,radians(Axis))*Layer_Scalereal-((Layer_Posreal+0.5)*Layer_Scalereal-0.5));
+	uvtemp = (uvtemp - Layer_Posreal - 0.5f) * BUFFER_SCREEN_SIZE;
+	uvtemp = rotate(uvtemp, 0, radians(Axis)) * Layer_Scale / BUFFER_SCREEN_SIZE + float2(0.5f, 0.5f);
 	float4 layer     = tex2D(FreezeSamplernew, uvtemp).rgba;
 
 	//layer.a=BlackBackground ? 1 : layer.a;

--- a/Shaders/StageDepthPlus with depth buffer modification/StageDepthPlusMap.fxh
+++ b/Shaders/StageDepthPlus with depth buffer modification/StageDepthPlusMap.fxh
@@ -23,11 +23,12 @@ float2 TextureCoordsModifier(float2 texcoord, float2 pos, float2 scale, float ax
 	
 	if (fh) {uvtemp.x = 1-uvtemp.x;}
 	if (fv) {uvtemp.y = 1-uvtemp.y;}
-	float2 Layer_Scalereal= float2 (scale.x-0.44,(scale.y-0.44)*STAGE_TEXTURE_WIDTH/STAGE_TEXTURE_HEIGHT);
+
 	float2 Layer_Posreal= float2((fh) ? -pos.x : pos.x, (fv) ? pos.y:-pos.y);
-	uvtemp= float2(((uvtemp.x*BUFFER_WIDTH-(BUFFER_WIDTH-BUFFER_HEIGHT)/2)/BUFFER_HEIGHT),uvtemp.y);
 	
-	uvtemp=(rotate(uvtemp,Layer_Posreal+0.5,radians(axis))*Layer_Scalereal-((Layer_Posreal+0.5)*Layer_Scalereal-0.5));
+	uvtemp = (uvtemp - Layer_Posreal - 0.5f) * BUFFER_SCREEN_SIZE;
+	
+	uvtemp=rotate(uvtemp,(Layer_Posreal + 0.5f), radians(axis)) * scale / BUFFER_SCREEN_SIZE + float2(0.5f, 0.5f);
 
 	return uvtemp;
 }

--- a/Shaders/StageDepthPlus.fx
+++ b/Shaders/StageDepthPlus.fx
@@ -507,14 +507,10 @@ namespace StageDepthPlus
 		if (FlipH) {uvtemp.x = 1-uvtemp.x;}//horizontal flip
 	    if (FlipV) {uvtemp.y = 1-uvtemp.y;} //vertical flip
 
-		float2 Layer_Scalereal= float2 (Layer_Scale.x-0.44,(Layer_Scale.y-0.44)*STAGE_TEXTURE_WIDTH/STAGE_TEXTURE_HEIGHT);
-
 	    float2 Layer_Posreal= float2((FlipH) ? -Layer_Pos.x : Layer_Pos.x, (FlipV) ? Layer_Pos.y:-Layer_Pos.y);
 
-		uvtemp= float2(((uvtemp.x*BUFFER_WIDTH-(BUFFER_WIDTH-BUFFER_HEIGHT)/2)/BUFFER_HEIGHT),uvtemp.y);
-		
-		uvtemp=(rotate(uvtemp,Layer_Posreal+0.5,radians(Axis))*Layer_Scalereal-((Layer_Posreal+0.5)*Layer_Scalereal-0.5));
-
+		uvtemp = (uvtemp - Layer_Posreal - 0.5f) * BUFFER_SCREEN_SIZE;
+		uvtemp = rotate(uvtemp, 0, radians(Axis)) * Layer_Scale / BUFFER_SCREEN_SIZE + float2(0.5f, 0.5f);
 
 		float4 layer  = RepeatTextureEnabled ? tex2D(Stageplus_sampler_Repeat, uvtemp).rgba : tex2D(Stageplus_sampler, uvtemp).rgba;
 


### PR DESCRIPTION
The scaling in FreezeShot now becomes more resonable.
AspectX/AspectY are removed from StageDepth and its derivatives (e.g. MultiLAyer, MultiStageDepth... from GShade)